### PR TITLE
Let the normalizer how schema and host

### DIFF
--- a/spec/Normalizer/NormalizerSpec.php
+++ b/spec/Normalizer/NormalizerSpec.php
@@ -16,13 +16,14 @@ class NormalizerSpec extends ObjectBehavior
         $this->shouldHaveType('Http\Client\Plugin\Normalizer\Normalizer');
     }
 
-    function it_normalize_request_to_string(RequestInterface $request)
+    function it_normalize_request_to_string(RequestInterface $request, UriInterface $uri)
     {
+        $uri->__toString()->willReturn('http://foo.com/bar');
         $request->getMethod()->willReturn('GET');
-        $request->getRequestTarget()->willReturn('/');
+        $request->getUri()->willReturn($uri);
         $request->getProtocolVersion()->willReturn('1.1');
 
-        $this->normalizeRequestToString($request)->shouldReturn('GET / 1.1');
+        $this->normalizeRequestToString($request)->shouldReturn('GET http://foo.com/bar 1.1');
     }
 
     function it_normalize_response_to_string(ResponseInterface $response)

--- a/src/Normalizer/Normalizer.php
+++ b/src/Normalizer/Normalizer.php
@@ -23,7 +23,7 @@ class Normalizer
      */
     public function normalizeRequestToString(RequestInterface $request)
     {
-        return sprintf('%s %s %s', $request->getMethod(), $request->getRequestTarget(), $request->getProtocolVersion());
+        return sprintf('%s %s %s', $request->getMethod(), $request->getUri()->__toString(), $request->getProtocolVersion());
     }
 
     /**


### PR DESCRIPTION
Reading my log files when using the LoggerPlugin I can see a entry like this: 

```
[2015-12-22 19:18:50] app.INFO: Emit request: "GET /language/translate/v2?key=param 1.1" {"request":"[object] (GuzzleHttp\\Psr7\\Request: {})"} []
[2015-12-22 19:18:50] app.INFO: Receive response: "200 OK 1.1" for request: "GET /language/translate/v2?key=param 1.1" {"request":"[object] (GuzzleHttp\\Psr7\\Request: {})","response":"[object] (GuzzleHttp\\Psr7\\Response: {})"} []
```

I would like to see to what host I was requesting data from. 

```
// Current
GET /language/translate/v2?key=param 1.1

// Suggested
GET https://www.googleapis.com/language/translate/v2?key=param 1.1
```

This PR makes sure I can see the host and schema in the log file. 
