### PR TITLE
AddHostPlugin

### DIFF
--- a/spec/AddHostPluginSpec.php
+++ b/spec/AddHostPluginSpec.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace spec\Http\Client\Plugin;
+
+use Http\Message\StreamFactory;
+use Http\Message\UriFactory;
+use Http\Promise\FulfilledPromise;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class AddHostPluginSpec extends ObjectBehavior
+{
+    function let(UriInterface $uri)
+    {
+        $this->beConstructedWith($uri);
+    }
+
+    function it_is_initializable(UriInterface $uri)
+    {
+        $uri->getHost()->shouldBeCalled()->willReturn('example.com');
+        $this->beConstructedWith($uri);
+        $this->shouldHaveType('Http\Client\Plugin\AddHostPlugin');
+    }
+
+    function it_is_a_plugin(UriInterface $uri)
+    {
+        $uri->getHost()->shouldBeCalled()->willReturn('example.com');
+        $this->beConstructedWith($uri);
+
+        $this->shouldImplement('Http\Client\Plugin\Plugin');
+    }
+
+    function it_adds_domain(
+        RequestInterface $request,
+        UriInterface $host,
+        UriInterface $uri
+    ) {
+        $host->getScheme()->shouldBeCalled()->willReturn('http://');
+        $host->getHost()->shouldBeCalled()->willReturn('example.com');
+
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->withUri($uri)->shouldBeCalled()->willReturn($request);
+
+        $uri->withScheme('http://')->shouldBeCalled()->willReturn($uri);
+        $uri->withHost('example.com')->shouldBeCalled()->willReturn($uri);
+        $uri->getHost()->shouldBeCalled()->willReturn('');
+
+        $this->beConstructedWith($host);
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+    function it_replaces_domain(
+        RequestInterface $request,
+        UriInterface $host,
+        UriInterface $uri
+    ) {
+        $host->getScheme()->shouldBeCalled()->willReturn('http://');
+        $host->getHost()->shouldBeCalled()->willReturn('example.com');
+
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->withUri($uri)->shouldBeCalled()->willReturn($request);
+
+        $uri->withScheme('http://')->shouldBeCalled()->willReturn($uri);
+        $uri->withHost('example.com')->shouldBeCalled()->willReturn($uri);
+
+
+        $this->beConstructedWith($host, ['replace'=>true]);
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+    function it_does_nothing_when_domain_exists(
+        RequestInterface $request,
+        UriInterface $host,
+        UriInterface $uri
+    ) {
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $uri->getHost()->shouldBeCalled()->willReturn('default.com');
+
+        $this->beConstructedWith($host);
+        $this->handleRequest($request, function () {}, function () {});
+    }
+}

--- a/src/AddHostPlugin.php
+++ b/src/AddHostPlugin.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Http\Client\Plugin;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Add schema and host to a request. Can be set to overwrite the schema and host if desired.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class AddHostPlugin implements Plugin
+{
+    /**
+     * @var UriInterface
+     */
+    private $host;
+
+    /**
+     * @var bool
+     */
+    private $replace;
+
+    /**
+     * @param UriInterface $host
+     * @param array        $config {
+     *
+     *     @var bool $replace True will replace all hosts, false will only add host when none is specified.
+     * }
+     */
+    public function __construct(UriInterface $host, array $config = [])
+    {
+        if ($host->getHost() === '') {
+            throw new \LogicException('Host can not be empty');
+        }
+
+        $this->host = $host;
+
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+        $options = $resolver->resolve($config);
+
+        $this->replace = $options['replace'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        if ($this->replace || $request->getUri()->getHost() === '') {
+            $uri = $request->getUri()->withHost($this->host->getHost());
+            $uri = $uri->withScheme($this->host->getScheme());
+
+            $request = $request->withUri($uri);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     */
+    private function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'replace' => false,
+        ]);
+        $resolver->setAllowedTypes('replace', 'bool');
+    }
+}


### PR DESCRIPTION
This will implement baseUri functionality. It copies Guzzle's behaviour when the input starts with a slash. 

// base uri  is http://foo.com/api/

| Input | Output |
| --- | --- |
| http://baz.com/biz | http://baz.com/biz |
| foo | http://foo.com/api/foo |
| /foo | http://foo.com/foo |
