### PR TITLE
Header Plugin

### DIFF
--- a/spec/HeaderAppendPluginSpec.php
+++ b/spec/HeaderAppendPluginSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\Http\Client\Plugin;
+
+use PhpSpec\Exception\Example\SkippingException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+
+class HeaderAppendPluginSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->beConstructedWith([]);
+        $this->shouldHaveType('Http\Client\Plugin\HeaderAppendPlugin');
+    }
+
+    public function it_is_a_plugin()
+    {
+        $this->beConstructedWith([]);
+        $this->shouldImplement('Http\Client\Plugin\Plugin');
+    }
+
+    public function it_appends_the_header(RequestInterface $request)
+    {
+        $this->beConstructedWith([
+            'foo'=>'bar',
+            'baz'=>'qux'
+        ]);
+
+        $request->withAddedHeader('foo', 'bar')->shouldBeCalled()->willReturn($request);
+        $request->withAddedHeader('baz', 'qux')->shouldBeCalled()->willReturn($request);
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+}

--- a/spec/HeaderDefaultsPluginSpec.php
+++ b/spec/HeaderDefaultsPluginSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace spec\Http\Client\Plugin;
+
+use PhpSpec\Exception\Example\SkippingException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+
+class HeaderDefaultsPluginSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->beConstructedWith([]);
+        $this->shouldHaveType('Http\Client\Plugin\HeaderDefaultsPlugin');
+    }
+
+    public function it_is_a_plugin()
+    {
+        $this->beConstructedWith([]);
+        $this->shouldImplement('Http\Client\Plugin\Plugin');
+    }
+
+    public function it_sets_the_default_header(RequestInterface $request)
+    {
+        $this->beConstructedWith([
+            'foo' => 'bar',
+            'baz' => 'qux'
+        ]);
+
+        $request->hasHeader('foo')->shouldBeCalled()->willReturn(false);
+        $request->withHeader('foo', 'bar')->shouldBeCalled()->willReturn($request);
+        $request->hasHeader('baz')->shouldBeCalled()->willReturn(true);
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+}

--- a/spec/HeaderRemovePluginSpec.php
+++ b/spec/HeaderRemovePluginSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace spec\Http\Client\Plugin;
+
+use PhpSpec\Exception\Example\SkippingException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+
+class HeaderRemovePluginSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->beConstructedWith([]);
+        $this->shouldHaveType('Http\Client\Plugin\HeaderRemovePlugin');
+    }
+
+    public function it_is_a_plugin()
+    {
+        $this->beConstructedWith([]);
+        $this->shouldImplement('Http\Client\Plugin\Plugin');
+    }
+
+    public function it_removes_the_header(RequestInterface $request)
+    {
+        $this->beConstructedWith([
+            'foo',
+            'baz'
+        ]);
+
+        $request->hasHeader('foo')->shouldBeCalled()->willReturn(false);
+
+        $request->hasHeader('baz')->shouldBeCalled()->willReturn(true);
+        $request->withoutHeader('baz')->shouldBeCalled()->willReturn($request);
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+}

--- a/spec/HeaderSetPluginSpec.php
+++ b/spec/HeaderSetPluginSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\Http\Client\Plugin;
+
+use PhpSpec\Exception\Example\SkippingException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+
+class HeaderSetPluginSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->beConstructedWith([]);
+        $this->shouldHaveType('Http\Client\Plugin\HeaderSetPlugin');
+    }
+
+    public function it_is_a_plugin()
+    {
+        $this->beConstructedWith([]);
+        $this->shouldImplement('Http\Client\Plugin\Plugin');
+    }
+
+    public function it_set_the_header(RequestInterface $request)
+    {
+        $this->beConstructedWith([
+            'foo'=>'bar',
+            'baz'=>'qux'
+        ]);
+
+        $request->withHeader('foo', 'bar')->shouldBeCalled()->willReturn($request);
+        $request->withHeader('baz', 'qux')->shouldBeCalled()->willReturn($request);
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+}

--- a/src/HeaderAppendPlugin.php
+++ b/src/HeaderAppendPlugin.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Http\Client\Plugin;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Adds headers to the request.
+ * If the header already exists the value will be appended to the current value.
+ *
+ * This only makes sense for headers that can have multiple values like 'Forwarded'
+ *
+ * @link https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+ *
+ * @author Soufiane Ghzal <sghzal@gmail.com>
+ */
+class HeaderAppendPlugin implements Plugin
+{
+    private $headers = [];
+
+    /**
+     * @param array $headers headers to add to the request
+     */
+    public function __construct(array $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        foreach ($this->headers as $header => $headerValue) {
+            $request = $request->withAddedHeader($header, $headerValue);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/HeaderDefaultsPlugin.php
+++ b/src/HeaderDefaultsPlugin.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Http\Client\Plugin;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Set default values for the request headers.
+ * If a given header already exists the value wont be replaced and the request wont be changed.
+ *
+ * @author Soufiane Ghzal <sghzal@gmail.com>
+ */
+class HeaderDefaultsPlugin implements Plugin
+{
+    private $headers = [];
+
+    /**
+     * @param array $headers headers to set to the request
+     */
+    public function __construct(array $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        foreach ($this->headers as $header => $headerValue) {
+            if (!$request->hasHeader($header)) {
+                $request = $request->withHeader($header, $headerValue);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/src/HeaderRemovePlugin.php
+++ b/src/HeaderRemovePlugin.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Http\Client\Plugin;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Removes headers from the request.
+ *
+ * @author Soufiane Ghzal <sghzal@gmail.com>
+ */
+class HeaderRemovePlugin implements Plugin
+{
+    private $headers = [];
+
+    /**
+     * @param array $headers headers to remove from the request
+     */
+    public function __construct(array $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        foreach ($this->headers as $header) {
+            if ($request->hasHeader($header)) {
+                $request = $request->withoutHeader($header);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/src/HeaderSetPlugin.php
+++ b/src/HeaderSetPlugin.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Http\Client\Plugin;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Set headers to the request.
+ * If the header does not exist it wil be set, if the header already exists it will be replaced.
+ *
+ * @author Soufiane Ghzal <sghzal@gmail.com>
+ */
+class HeaderSetPlugin implements Plugin
+{
+    private $headers = [];
+
+    /**
+     * @param array $headers headers to set to the request
+     */
+    public function __construct(array $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        foreach ($this->headers as $header => $headerValue) {
+            $request = $request->withHeader($header, $headerValue);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Adding `HeaderPlugin` that has the ability to set / remove headers.

``` php
// set the header 'foo: bar' if the header does not exist in the request
$headerPlugin->withHeader('foo', 'bar'); 

// set the header 'foo: bar' even if the header 'fooè already exists
$headerPlugin->withHeader('foo', 'bar', true);

// remove the header 'foo' if it exists on the request
$headerPlugin->withoutHeader('foo');
```
