### PR TITLE
use options resolver where applicable, fix decoder plugin gzip handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+### Changed
+
+- Using array options for DecoderPlugin, RedirectPlugin and RetryPlugin
+
+### Fixed
+
+- Decoder plugin no longer sends accept header for encodings that require gzip if gzip is not available
 
 ## 0.1.0 - 2016-01-13
 

--- a/spec/DecoderPluginSpec.php
+++ b/spec/DecoderPluginSpec.php
@@ -116,7 +116,7 @@ class DecoderPluginSpec extends ObjectBehavior
 
     function it_does_not_decode_with_content_encoding(RequestInterface $request, ResponseInterface $response)
     {
-        $this->beConstructedWith(false);
+        $this->beConstructedWith(['use_content_encoding' => false]);
 
         $request->withHeader('TE', ['gzip', 'deflate', 'compress', 'chunked'])->shouldBeCalled()->willReturn($request);
         $request->withHeader('Accept-Encoding', ['gzip', 'deflate', 'compress'])->shouldNotBeCalled();

--- a/spec/RedirectPluginSpec.php
+++ b/spec/RedirectPluginSpec.php
@@ -223,7 +223,7 @@ class RedirectPluginSpec extends ObjectBehavior
             }
         };
 
-        $this->beConstructedWith(true, false);
+        $this->beConstructedWith(['preserve_header' => true, 'use_default_for_multiple' => false]);
         $responseRedirect->getStatusCode()->willReturn('300');
 
         $promise = $this->handleRequest($request, $next, function () {});
@@ -301,7 +301,7 @@ class RedirectPluginSpec extends ObjectBehavior
         ResponseInterface $finalResponse,
         Promise $promise
     ) {
-        $this->beConstructedWith(['Accept']);
+        $this->beConstructedWith(['preserve_header' => ['Accept']]);
 
         $request->getRequestTarget()->willReturn('/original');
 
@@ -377,9 +377,9 @@ class RedirectPluginSpec extends ObjectBehavior
 
 class RedirectPluginStub extends RedirectPlugin
 {
-    public function __construct(UriInterface $uri, $storedUrl, $status, $preserveHeader = true, $useDefaultForMultiple = true)
+    public function __construct(UriInterface $uri, $storedUrl, $status, array $config = [])
     {
-        parent::__construct($preserveHeader, $useDefaultForMultiple);
+        parent::__construct($config);
 
         $this->redirectStorage[$storedUrl] = [
             'uri' => $uri,

--- a/src/CachePlugin.php
+++ b/src/CachePlugin.php
@@ -32,7 +32,7 @@ class CachePlugin implements Plugin
     private $config;
 
     /**
-     * Available options are
+     * Available options for $config are
      *  - respect_cache_headers: Whether to look at the cache directives or ignore them.
      *  - default_ttl: If we do not respect cache headers or can't calculate a good ttl, use this value.
      *

--- a/src/RetryPlugin.php
+++ b/src/RetryPlugin.php
@@ -5,9 +5,10 @@ namespace Http\Client\Plugin;
 use Http\Client\Exception;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Retry the request if it has somehow failed.
+ * Retry the request if an exception is thrown.
  *
  * By default will retry only one time.
  *
@@ -30,11 +31,21 @@ class RetryPlugin implements Plugin
     private $retryStorage = [];
 
     /**
-     * @param int $retry Number of retry before sending an exception
+     * Available options for $config are:
+     *  - retries: Number of retries to attempt if an exception occurs before letting the exception bubble up.
+     *
+     * @param array $config
      */
-    public function __construct($retry = 1)
+    public function __construct(array $config = [])
     {
-        $this->retry = $retry;
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'retries' => 1,
+        ]);
+        $resolver->setAllowedTypes('retries', 'int');
+        $options = $resolver->resolve($config);
+
+        $this->retry = $options['retries'];
     }
 
     /**


### PR DESCRIPTION
follow up of the discussion in https://github.com/php-http/documentation/pull/76 - i propose to use the OptionsResolver for configuration options on plugins. This is both more readable on the calling side and more flexible when we need to add more options in the future.

i mixed in the same PR a fix for the deccoder plugin to not claim to support gzip if it does not support gzip. this might hide the problem of a missing gzip library a bit.
