### PR TITLE
Do not pull unneeded dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,6 @@
         "php": ">=5.4",
         "php-http/httplug": "^1.0",
         "php-http/message-factory": "^1.0.2",
-        "psr/log": "^1.0",
-        "psr/cache": "^1.0",
         "php-http/client-common": "^1.0",
         "php-http/message": "^1.0",
         "symfony/options-resolver": "^2.6|^3.0"
@@ -23,7 +21,13 @@
     "require-dev": {
         "symfony/stopwatch": "^2.3",
         "phpspec/phpspec": "^2.4",
-        "henrikbjorn/phpspec-code-coverage" : "^1.0"
+        "henrikbjorn/phpspec-code-coverage" : "^1.0",
+        "psr/log": "^1.0",
+        "psr/cache": "^1.0"
+    },
+    "conflict": {
+        "psr/log": ">=2.0.0",
+        "psr/cache": ">=2.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi, I am asking you to reconsider making psr/cache and psr/log hard dependencies of this project. The change done in #36 does not bring any benefits to this package.

If somebody wants to use one of the plugins that depend on the psr/log and/or psr/cache interface they will have to install a concrete implementation of those interfaces. When they do that, those packages will pull in the required interfaces.

If we leave it as it is, we are just adding one more package to install that is not always needed.
