### PR TITLE
Fix #67 Fixed Cookie creation in cookie plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+
+## 1.0.0 - 2016-01-28
+
 ### Added
 
  - New Header plugins (see the documentation)
@@ -12,6 +15,7 @@
 ### Fixed
 
 - Decoder plugin no longer sends accept header for encodings that require gzip if gzip is not available
+
 
 ## 0.1.0 - 2016-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.0.1 - 2016-01-29
+
+### Changed
+
+ - Set the correct header for the Content-Length when in chunked mode.
 
 ## 1.0.0 - 2016-01-28
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ composer require php-http/plugins
 
 ## Documentation
 
-Please see the [official documentation](http://docs.php-http.org).
+Please see the [official documentation](http://docs.php-http.org/en/latest/plugins/index.html).
 
 
 ## Testing
@@ -38,8 +38,7 @@ Please see our [contributing guide](http://docs.php-http.org/en/latest/developme
 
 ## Security
 
-If you discover any security related issues, please contact us at [security@httplug.io](mailto:security@httplug.io)
-or [security@php-http.org](mailto:security@php-http.org).
+If you discover any security related issues, please contact us at [security@php-http.org](mailto:security@php-http.org).
 
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2-dev"
+            "dev-master": "1.0-dev"
         }
-    },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,6 @@
         "php": ">=5.4",
         "php-http/httplug": "^1.0",
         "php-http/message-factory": "^1.0.2",
-        "psr/log": "^1.0",
-        "psr/cache": "^1.0",
         "php-http/client-common": "^1.0",
         "php-http/message": "^1.0",
         "symfony/options-resolver": "^2.6|^3.0"
@@ -23,7 +21,13 @@
     "require-dev": {
         "symfony/stopwatch": "^2.3",
         "phpspec/phpspec": "^2.4",
-        "henrikbjorn/phpspec-code-coverage" : "^1.0"
+        "henrikbjorn/phpspec-code-coverage" : "^1.0",
+        "psr/log": "^1.0",
+        "psr/cache": "^1.0"
+    },
+    "conflict": {
+        "psr/log": ">=2.0.0",
+        "psr/cache": ">=2.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4",
         "php-http/httplug": "^1.0",
-        "php-http/message-factory": "^1.0",
+        "php-http/message-factory": "^1.0.2",
         "psr/log": "^1.0",
         "psr/cache": "^1.0",
         "php-http/client-common": "^1.0",

--- a/spec/ContentLengthPluginSpec.php
+++ b/spec/ContentLengthPluginSpec.php
@@ -37,6 +37,7 @@ class ContentLengthPluginSpec extends ObjectBehavior
 
         $stream->getSize()->shouldBeCalled()->willReturn(null);
         $request->withBody(Argument::type('Http\Message\Encoding\ChunkStream'))->shouldBeCalled()->willReturn($request);
+        $request->withAddedHeader('Transfer-Encoding', 'chunked')->shouldBeCalled()->willReturn($request);
 
         $this->handleRequest($request, function () {}, function () {});
     }

--- a/src/ContentLengthPlugin.php
+++ b/src/ContentLengthPlugin.php
@@ -24,6 +24,7 @@ class ContentLengthPlugin implements Plugin
             if (null === $stream->getSize()) {
                 $stream = new ChunkStream($stream);
                 $request = $request->withBody($stream);
+                $request = $request->withAddedHeader('Transfer-Encoding', 'chunked');
             } else {
                 $request = $request->withHeader('Content-Length', $stream->getSize());
             }


### PR DESCRIPTION
fix #67

Fix applied by calculating the expireIn (max-age) seconds instead of expire datetime.
Expanded save spec by using a more complete cookie.

Use DATE_COOKIE constant instead of DateTime constant.
Expand the cookie header content with all parts.
